### PR TITLE
Fix PWA start_url to prevent 'forbidden' error

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Māori Fishing Calendar",
   "short_name": "Fishing Calendar",
-  "start_url": ".",
+  "start_url": "index.html",
   "display": "standalone",
   "background_color": "#ffffff",
   "theme_color": "#0d47a1",

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,5 @@
 const CACHE_NAME = 'maori-fishing-calendar-cache-v1';
 const urlsToCache = [
-  '.',
   'index.html',
   'style.css',
   'script.js',


### PR DESCRIPTION
When installed as a PWA, the app would fail to launch, showing a "forbidden: no directory listing" error. This was caused by the `start_url` in `manifest.json` being set to ".", which points to the root directory.

This commit changes the `start_url` to "index.html" to explicitly specify the entry point of the application.

Additionally, the redundant "." entry has been removed from the `urlsToCache` array in the service worker (`sw.js`).