### PR TITLE
Fix blank trip creation

### DIFF
--- a/index.html
+++ b/index.html
@@ -219,7 +219,7 @@
                             <textarea id="trip-best-times" placeholder="Best Times / Notes" rows="3" class="md:col-span-2 p-2 border rounded dark:bg-gray-600 dark:border-gray-500"></textarea>
                         </div>
                         <div class="flex space-x-2 mt-4">
-                            <button id="save-trip-btn" class="flex-1 px-4 py-2 bg-green-500 text-white rounded hover:bg-green-600 transition">Save Trip</button>
+                            <button id="save-trip-btn" class="flex-1 px-4 py-2 bg-green-500 text-white rounded hover:bg-green-600 transition disabled:bg-gray-400 disabled:cursor-not-allowed" disabled>Save Trip</button>
                             <button id="cancel-edit-trip-btn" class="flex-1 px-4 py-2 bg-gray-400 text-white rounded-md hover:bg-gray-500 transition hidden">Cancel Edit</button>
                         </div>
                         <div id="save-trip-success-msg" class="text-green-500 text-sm mt-2 text-center hidden">Trip saved!</div>

--- a/script.js
+++ b/script.js
@@ -426,6 +426,20 @@ function initDB(callback) {
     };
 }
 
+function validateTripForm() {
+    const tripInputs = [
+        document.getElementById('trip-water'),
+        document.getElementById('trip-location'),
+        document.getElementById('trip-hours'),
+        document.getElementById('trip-total-fish'),
+        document.getElementById('trip-companions'),
+        document.getElementById('trip-best-times')
+    ];
+    const saveTripBtn = document.getElementById('save-trip-btn');
+    const isAnyFieldFilled = tripInputs.some(input => input.value.trim() !== '');
+    saveTripBtn.disabled = !isAnyFieldFilled;
+}
+
 function clearTripForm() {
     document.getElementById('trip-water').value = '';
     document.getElementById('trip-location').value = '';
@@ -437,6 +451,7 @@ function clearTripForm() {
     document.getElementById('trip-form-title').textContent = 'Log a New Trip';
     document.getElementById('save-trip-btn').textContent = 'Save Trip';
     document.getElementById('cancel-edit-trip-btn').classList.add('hidden');
+    validateTripForm();
 }
 
 function saveTrip() {
@@ -690,6 +705,17 @@ function setupEventListeners() {
         });
     }
 
+    const tripInputs = [
+        'trip-water', 'trip-location', 'trip-hours',
+        'trip-total-fish', 'trip-companions', 'trip-best-times'
+    ];
+    tripInputs.forEach(id => {
+        const input = document.getElementById(id);
+        if (input) {
+            input.addEventListener('input', validateTripForm);
+        }
+    });
+
     const handleManualLocationSearch = () => {
         const query = locationInput.value;
         if (query.length < 2) return;
@@ -816,6 +842,7 @@ function createBiteTimeElement(biteTime) {
 
 function showModal(day, month, year) {
     clearTripForm(); // Reset the form every time the modal is shown or day is changed
+    validateTripForm(); // Ensure button state is correct on modal open
     modalCurrentDay = day;
     modalCurrentMonth = month;
     modalCurrentYear = year;

--- a/script.js
+++ b/script.js
@@ -569,6 +569,7 @@ function editTrip(id) {
         document.getElementById('trip-form-title').textContent = 'Editing Trip';
         document.getElementById('save-trip-btn').textContent = 'Update Trip';
         document.getElementById('cancel-edit-trip-btn').classList.remove('hidden');
+        validateTripForm();
     };
 }
 


### PR DESCRIPTION
Prevented Blank Trip Creation: I initially modified the trip logging form so that the 'Save Trip' button is disabled by default. It only becomes active when you start entering information into any of the fields (like 'Water Body', 'Location', etc.). This stops blank trips from being created.

Fixed the 'Edit Trip' Button: I then addressed the issue where the 'Update Trip' button was incorrectly disabled when you went to edit a trip. I've now ensured that the button is enabled as soon as the form is filled with the existing trip details, allowing you to save your changes.