### PR TITLE
Fix: Reset modal scroll position on open

### DIFF
--- a/script.js
+++ b/script.js
@@ -1029,13 +1029,6 @@ function showTripLogModal() {
     displayTrips(dateStrForDisplay);
 
     openModalWithAnimation(tripLogModal);
-
-    const modalContent = tripLogModal.querySelector('.overflow-y-auto');
-    if (modalContent) {
-        setTimeout(() => {
-            modalContent.scrollTop = 0;
-        }, 0);
-    }
 }
 
 // Generic modal handlers
@@ -1046,6 +1039,15 @@ function openModalWithAnimation(modal) {
     setTimeout(() => { // Ensures display property is set before transition starts
         modal.classList.add('is-visible');
     }, 10);
+
+    // Reset scroll position of the scrollable container inside the modal
+    const scrollContainer = modal.querySelector('.overflow-y-auto');
+    if (scrollContainer) {
+        // Use setTimeout to ensure the element is visible and scrollable before resetting.
+        setTimeout(() => {
+            scrollContainer.scrollTop = 0;
+        }, 0);
+    }
 }
 
 function closeModalWithAnimation(modal) {


### PR DESCRIPTION
When a modal was closed and then reopened, it would retain its previous scroll position, particularly on mobile devices. This was because the modal was simply hidden and shown, and the browser preserved the scroll state.

This change modifies the generic `openModalWithAnimation` function to reset the `scrollTop` of any scrollable container within the modal to 0 whenever it is opened. This ensures all modals consistently appear at the top.

The redundant scroll-reset logic in the `showTripLogModal` function has been removed, as it is now handled by the centralized function.