### PR TITLE
Fix remaining JavaScript error on page load

### DIFF
--- a/script.js
+++ b/script.js
@@ -55,7 +55,7 @@ let modalCurrentDay = null;
 let modalCurrentMonth = null;
 let modalCurrentYear = null;
 
-let calendarDays, currentMonthElement, prevMonthButton, nextMonthButton, lunarModal, closeModal, modalCloseBtn, modalTitle, modalSummary, modalDate, modalQuality, modalMoonAge, modalMoonIllumination, majorBites, minorBites, modalPrevDay, modalNextDay, currentMoonPhase, currentMoonAge, currentMoonIllumination;
+let calendarDays, currentMonthElement, prevMonthButton, nextMonthButton, lunarModal, closeModal, modalTitle, modalSummary, modalDate, modalQuality, modalMoonAge, modalMoonIllumination, majorBites, minorBites, modalPrevDay, modalNextDay, currentMoonPhase, currentMoonAge, currentMoonIllumination;
 
 const monthNames = [
     "January", "February", "March", "April", "May", "June",
@@ -640,7 +640,6 @@ function initDOMElements() {
     nextMonthButton = document.getElementById('nextMonth');
     lunarModal = document.getElementById('lunarModal');
     closeModal = document.getElementById('closeModal');
-    modalCloseBtn = document.getElementById('modalCloseBtn');
     modalTitle = document.getElementById('modalTitle');
     modalSummary = document.getElementById('modalSummary');
     modalDate = document.getElementById('modalDate');
@@ -770,7 +769,6 @@ function setupEventListeners() {
         renderCalendar();
     });
     closeModal.addEventListener('click', hideModal);
-    modalCloseBtn.addEventListener('click', hideModal);
     lunarModal.addEventListener('click', handleModalClicks);
 
     modalPrevDay.addEventListener('click', showPreviousDay);


### PR DESCRIPTION
This commit fixes a `TypeError` that occurred on page load. The error was caused by a reference to a non-existent DOM element with the ID `modalCloseBtn`.

This commit removes the code that references this element, which resolves the error. The functionality is preserved because another close button with the ID `closeModal` already handles closing the modal.