### PR TITLE
feat: Add swipe gestures for calendar and modal navigation

### DIFF
--- a/script.js
+++ b/script.js
@@ -1013,6 +1013,20 @@ function setupEventListeners() {
 
         tripLogModal.addEventListener('click', handleModalClicks);
     }
+
+    // Swipe gestures for calendar
+    const calendarContainer = document.querySelector('#calendarDays');
+    if (calendarContainer) {
+        addSwipeListeners(calendarContainer, () => nextMonthButton.click(), () => prevMonthButton.click());
+    }
+
+    // Swipe gestures for modal
+    if (lunarModal) {
+        const modalContent = lunarModal.querySelector('.relative');
+        if (modalContent) {
+            addSwipeListeners(modalContent, showNextDay, showPreviousDay);
+        }
+    }
 }
 
 function updateCurrentMoonInfo() {
@@ -2231,6 +2245,29 @@ function displaySearchResults(results) {
         resultEl.innerHTML = content;
         resultsContainer.appendChild(resultEl);
     });
+}
+
+function addSwipeListeners(element, onSwipeLeft, onSwipeRight) {
+    let touchstartX = 0;
+    let touchendX = 0;
+    const threshold = 50; // Minimum distance for a swipe
+
+    element.addEventListener('touchstart', (e) => {
+        touchstartX = e.changedTouches[0].screenX;
+    }, { passive: true });
+
+    element.addEventListener('touchend', (e) => {
+        touchendX = e.changedTouches[0].screenX;
+        const swipeDistance = touchendX - touchstartX;
+
+        if (Math.abs(swipeDistance) >= threshold) {
+            if (swipeDistance < 0) {
+                onSwipeLeft();
+            } else {
+                onSwipeRight();
+            }
+        }
+    }, { passive: true });
 }
 
 document.addEventListener('DOMContentLoaded', initCalendar);


### PR DESCRIPTION
This commit introduces swipe gesture support to enhance user navigation on touch-enabled devices.

- **Main Calendar:** Users can now swipe left or right on the calendar grid to navigate to the next or previous month, respectively.
- **Daily Modal:** Swiping left or right within the daily detail modal now navigates to the next or previous day.

A reusable `addSwipeListeners` utility function has been added to `script.js` to handle touch events and detect horizontal swipes, which is then applied to the relevant calendar and modal elements.