### PR TITLE
Fix/pwa cache update

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'maori-fishing-calendar-cache-v3';
+const CACHE_NAME = 'maori-fishing-calendar-cache-v4';
 const urlsToCache = [
   '/',
   'index.html',
@@ -12,6 +12,7 @@ const urlsToCache = [
 ];
 
 self.addEventListener('install', event => {
+  self.skipWaiting();
   event.waitUntil(
     caches.open(CACHE_NAME)
       .then(cache => {


### PR DESCRIPTION
Feat: Force immediate PWA updates with skipWaiting

The previous fix to a network-first strategy was not enough to prevent the old service worker from controlling the page, leading to a stale PWA client.

This commit makes the service worker update process more aggressive by:
1.  Adding `self.skipWaiting()` to the `install` event. This forces the new service worker to activate immediately after it has finished installing, rather than waiting for all client tabs to be closed.
2.  Incrementing the cache version to `v4` to ensure this new service worker is installed.

This ensures that users receive the latest version of the application as soon as it's available, without needing to manually close tabs or clear their cache.