### PR TITLE
Fix/bite modal navigation

### DIFF
--- a/script.js
+++ b/script.js
@@ -665,11 +665,6 @@ function initCalendar() {
 }
 
 function handleModalClicks(e) {
-    if (e.target === lunarModal) {
-        hideModal();
-        return;
-    }
-
     const target = e.target.closest('button');
     if (!target) return;
 
@@ -791,7 +786,13 @@ function setupEventListeners() {
         renderCalendar();
     });
     closeModal.addEventListener('click', hideModal);
-    lunarModal.addEventListener('click', handleModalClicks);
+
+    // This listener handles clicks on the modal's backdrop to close it.
+    lunarModal.addEventListener('click', (e) => {
+        if (e.target === lunarModal) {
+            hideModal();
+        }
+    });
 
     modalPrevDay.addEventListener('click', showPreviousDay);
     modalNextDay.addEventListener('click', showNextDay);

--- a/script.js
+++ b/script.js
@@ -1246,15 +1246,18 @@ function showTripLogModal() {
 function openModalWithAnimation(modal) {
     if (!modal) return;
 
-    // If there's an active modal, cover its content
+    // If there's an active modal, cover its content, but only if it's a DIFFERENT modal.
     if (modalStack.length > 0) {
-        const currentModal = modalStack[modalStack.length - 1];
-        if (currentModal && currentModal.firstElementChild) {
-            currentModal.firstElementChild.classList.add('modal-content-covered');
+        const currentTopModal = modalStack[modalStack.length - 1];
+        if (currentTopModal !== modal && currentTopModal.firstElementChild) {
+            currentTopModal.firstElementChild.classList.add('modal-content-covered');
         }
     }
 
-    modalStack.push(modal);
+    // Only push the modal to the stack if it's not already the top-most one.
+    if (modalStack.length === 0 || modalStack[modalStack.length - 1] !== modal) {
+        modalStack.push(modal);
+    }
 
     document.body.classList.add('modal-open');
     modal.classList.remove('hidden');
@@ -1300,8 +1303,6 @@ function closeModalWithAnimation(modal) {
 }
 
 function showModal(day, month, year) {
-    const wasHidden = lunarModal.classList.contains('hidden');
-
     clearTripForm(); // Reset the form every time the modal is shown or day is changed
     validateTripForm(); // Ensure button state is correct on modal open
     modalCurrentDay = day;
@@ -1342,9 +1343,7 @@ function showModal(day, month, year) {
     updateOpenTripLogButton(dateStrForDisplay);
 
     updateNavigationButtons();
-    if (wasHidden) {
-        openModalWithAnimation(lunarModal);
-    }
+    openModalWithAnimation(lunarModal);
 }
 
 function showPreviousDay() {

--- a/script.js
+++ b/script.js
@@ -1300,6 +1300,8 @@ function closeModalWithAnimation(modal) {
 }
 
 function showModal(day, month, year) {
+    const wasHidden = lunarModal.classList.contains('hidden');
+
     clearTripForm(); // Reset the form every time the modal is shown or day is changed
     validateTripForm(); // Ensure button state is correct on modal open
     modalCurrentDay = day;
@@ -1340,7 +1342,9 @@ function showModal(day, month, year) {
     updateOpenTripLogButton(dateStrForDisplay);
 
     updateNavigationButtons();
-    openModalWithAnimation(lunarModal);
+    if (wasHidden) {
+        openModalWithAnimation(lunarModal);
+    }
 }
 
 function showPreviousDay() {


### PR DESCRIPTION
The Problem: The bite modal would stop working correctly after a single day navigation (either by button click or swipe). On the second attempt to navigate, the action would incorrectly close the modal.

The Solution (in three stages of debugging):

Initial Analysis (Incorrect): My first attempt focused on the event listeners for the navigation buttons. I believed there was a conflict and refactored how clicks were handled. This did not solve the underlying issue.

Second Analysis (Incorrect): My next attempt correctly identified that the modal's state was being corrupted on navigation, but I misdiagnosed the cause. I modified the showModal function to prevent it from re-running the opening animation, which also proved to be an incomplete fix.

Final & Correct Fix: After the issue persisted, a deeper dive revealed the true root cause was in the generic openModalWithAnimation function. This function is responsible for managing all modals, including stacking them.

The Bug: When navigating days, the code was calling this function for a modal that was already open. The function mistakenly treated this as opening a new modal on top of itself. This triggered logic that applied a "covered" overlay style to the modal content (blocking further clicks) and corrupted an internal list of open modals (modalStack).
The Change: I modified openModalWithAnimation to be more intelligent. It now checks if the modal being opened is the same as the one already at the top of the stack. If it is, it no longer applies the "covered" style or adds a duplicate entry to the stack. This prevents the state corruption entirely.
In short, the final change was a targeted fix to the core modal animation logic in script.js to make it correctly handle the specific case of updating a modal that is already open. This resolved the bug.