### PR TITLE
feat: Close active modal on Escape key press

### DIFF
--- a/script.js
+++ b/script.js
@@ -1162,6 +1162,16 @@ function setupEventListeners() {
             addSwipeListeners(modalContent, showNextDay, showPreviousDay);
         }
     }
+
+    // Add a global listener for the Escape key to close the top-most modal.
+    document.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape') {
+            if (modalStack.length > 0) {
+                const topModal = modalStack[modalStack.length - 1];
+                closeModalWithAnimation(topModal);
+            }
+        }
+    });
 }
 
 function updateCurrentMoonInfo() {


### PR DESCRIPTION
Adds a `keydown` event listener to the document to listen for the 'Escape' key.

When the Escape key is pressed, the event listener checks if there are any modals open by looking at the `modalStack`. If the stack is not empty, it closes the top-most modal using the existing `closeModalWithAnimation` function.

This improves user experience and accessibility by providing a common keyboard shortcut to dismiss modals.