### PR TITLE
Feature/open new trip modal directly

### DIFF
--- a/script.js
+++ b/script.js
@@ -1221,25 +1221,32 @@ function updateOpenTripLogButton(dateStr) {
 }
 
 function showTripLogModal() {
-    const tripLogModal = document.getElementById('tripLogModal');
-    if (!tripLogModal) return;
-
-    const date = new Date(modalCurrentYear, modalCurrentMonth, modalCurrentDay);
-    const dayName = dayNames[date.getDay()];
-    const dayOfMonth = date.getDate();
-    const monthName = monthNames[date.getMonth()].substring(0, 3);
-    const formattedDate = `${dayName} ${dayOfMonth} ${monthName}`;
-
-    const tripLogDateEl = document.getElementById('trip-log-date');
-    if (tripLogDateEl) {
-        tripLogDateEl.textContent = formattedDate;
-    }
-
-    // Populate the trips for the currently selected day
     const dateStrForDisplay = `${modalCurrentYear}-${(modalCurrentMonth + 1).toString().padStart(2, '0')}-${modalCurrentDay.toString().padStart(2, '0')}`;
-    displayTrips(dateStrForDisplay);
 
-    openModalWithAnimation(tripLogModal);
+    checkIfTripsExist(dateStrForDisplay, (tripsExist) => {
+        if (tripsExist) {
+            const tripLogModal = document.getElementById('tripLogModal');
+            if (!tripLogModal) return;
+
+            const date = new Date(modalCurrentYear, modalCurrentMonth, modalCurrentDay);
+            const dayName = dayNames[date.getDay()];
+            const dayOfMonth = date.getDate();
+            const monthName = monthNames[date.getMonth()].substring(0, 3);
+            const formattedDate = `${dayName} ${dayOfMonth} ${monthName}`;
+
+            const tripLogDateEl = document.getElementById('trip-log-date');
+            if (tripLogDateEl) {
+                tripLogDateEl.textContent = formattedDate;
+            }
+
+            displayTrips(dateStrForDisplay);
+            openModalWithAnimation(tripLogModal);
+        } else {
+            // No trips exist, open the "Log a New Trip" modal directly
+            clearTripForm();
+            openModalWithAnimation(document.getElementById('tripDetailsModal'));
+        }
+    });
 }
 
 // Generic modal handlers


### PR DESCRIPTION
When a user is in the Bite Modal and there are no trips for the selected day, clicking the 'Create Trip Log' button now opens the 'Log a New Trip' modal directly.

This improves the user experience by saving a click and making the process of adding the first trip for a day more efficient.
