### PR TITLE
fix: Force service worker update by bumping cache version

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'maori-fishing-calendar-cache-v4';
+const CACHE_NAME = 'maori-fishing-calendar-cache-v5';
 const urlsToCache = [
   '/',
   'index.html',


### PR DESCRIPTION
The previous deployment caused a page load regression because the service worker did not update correctly. This can happen if the browser continues to use an old, cached version of the service worker's assets.

By incrementing the `CACHE_NAME` from `v4` to `v5`, we force the browser to treat the service worker as a new version. This triggers the `install` and `activate` events, which clears out the old cache and ensures the new, correct assets are served, resolving the loading issue.