### PR TITLE
fix: Restore PWA offline support with Cache First SW

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,27 +1,86 @@
+const CACHE_NAME = 'maori-fishing-calendar-cache-v8';
+const urlsToCache = [
+  '/',
+  'index.html',
+  'style.css',
+  'tacklebox.css',
+  'script.js',
+  'js/tacklebox.js',
+  'manifest.json',
+  '/icons/icon-192x192.png',
+  '/icons/icon-512x512.png',
+  'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css',
+  'https://cdn.tailwindcss.com'
+];
+
 self.addEventListener('install', event => {
-  console.log('Installing passthrough service worker.');
+  console.log('Installing final service worker...');
+  event.waitUntil(
+    caches.open(CACHE_NAME)
+      .then(cache => {
+        console.log('Opened cache for pre-caching.');
+        // Use a more robust caching strategy that handles CORS
+        const cachePromises = urlsToCache.map(urlToCache => {
+          const request = new Request(urlToCache, { mode: 'no-cors' });
+          return fetch(request).then(response => cache.put(urlToCache, response)).catch(err => {
+              console.warn(`Failed to cache ${urlToCache}:`, err);
+          });
+        });
+        return Promise.all(cachePromises);
+      })
+  );
   self.skipWaiting();
 });
 
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request)
+      .then(response => {
+        // Cache hit - return response
+        if (response) {
+          return response;
+        }
+
+        // Not in cache - go to network and cache the response for next time
+        return fetch(event.request).then(
+          (response) => {
+            // Check if we received a valid response
+            if(!response || response.status !== 200) {
+              return response;
+            }
+
+            // IMPORTANT: Clone the response. A response is a stream
+            // and because we want the browser to consume the response
+            // as well as the cache consuming the response, we need
+            // to clone it so we have two streams.
+            var responseToCache = response.clone();
+
+            caches.open(CACHE_NAME)
+              .then((cache) => {
+                cache.put(event.request, responseToCache);
+              });
+
+            return response;
+          }
+        );
+      })
+    );
+});
+
 self.addEventListener('activate', event => {
-  console.log('Activating passthrough service worker.');
-  // Clean up all old caches
+  console.log('Activating final service worker...');
+  const cacheWhitelist = [CACHE_NAME];
   event.waitUntil(
     caches.keys().then(cacheNames => {
       return Promise.all(
         cacheNames.map(cacheName => {
-          console.log('Deleting old cache:', cacheName);
-          return caches.delete(cacheName);
+          if (cacheWhitelist.indexOf(cacheName) === -1) {
+            console.log('Deleting old cache:', cacheName);
+            return caches.delete(cacheName);
+          }
         })
       );
     })
   );
   return self.clients.claim();
-});
-
-self.addEventListener('fetch', event => {
-  // Do nothing. Let the request go to the network.
-  // This is the default behavior when there's no event.respondWith().
-  // Adding a log to be sure it's running.
-  console.log('Passthrough SW: Fetching', event.request.url);
 });


### PR DESCRIPTION
This commit implements the final, production-ready service worker to restore offline functionality and fix the page load regression.

The new service worker uses a standard "Cache First, falling back to Network" strategy. This ensures the app shell loads reliably and quickly from the cache, while still fetching and caching new content from the network.

The cache version has been bumped to `v8` to ensure this new worker is installed and activated cleanly, and all previous diagnostic or faulty service workers and their caches are removed.