### PR TITLE
fix: Resolve race condition on Firestore initialization

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -36,7 +36,7 @@ let storage; // For Firebase Storage
 
 // Enable Firestore offline persistence.
 // This must be done before any other Firestore operations.
-firebase.firestore().enablePersistence({ synchronizeTabs: true })
+const persistencePromise = firebase.firestore().enablePersistence({ synchronizeTabs: true })
   .catch((err) => {
     if (err.code == 'failed-precondition') {
       // Multiple tabs open, persistence can only be enabled
@@ -51,6 +51,7 @@ firebase.firestore().enablePersistence({ synchronizeTabs: true })
 
 // Listen for authentication state changes
 firebase.auth().onAuthStateChanged(async (user) => {
+    await persistencePromise; // Wait for persistence to be enabled before proceeding.
     currentUser = user; // Set the current user
 
     const signInButton = document.getElementById('signInButton');


### PR DESCRIPTION
A race condition was causing the page to fail to load. The `enablePersistence()` call, which is asynchronous, was not being awaited. This meant that Firestore could be initialized via `firebase.firestore()` inside the `onAuthStateChanged` listener before persistence was actually enabled, causing an unhandled exception that blocked script execution.

This commit fixes the issue by capturing the `enablePersistence` promise and explicitly awaiting it at the beginning of the `onAuthStateChanged` listener. This ensures that persistence is always fully enabled before any other Firestore operations are attempted, resolving the race condition.