### PR TITLE
Feature/timestamp export

### DIFF
--- a/script.js
+++ b/script.js
@@ -1529,9 +1529,17 @@ function exportData() {
         zip.file("data.json", JSON.stringify(exportDataContainer, null, 2));
 
         zip.generateAsync({ type: "blob" }).then(content => {
+            const now = new Date();
+            const year = now.getFullYear();
+            const month = (now.getMonth() + 1).toString().padStart(2, '0');
+            const day = now.getDate().toString().padStart(2, '0');
+            const hours = now.getHours().toString().padStart(2, '0');
+            const minutes = now.getMinutes().toString().padStart(2, '0');
+            const timestamp = `${year}-${month}-${day}_${hours}${minutes}`;
+
             const downloadAnchorNode = document.createElement('a');
             downloadAnchorNode.href = URL.createObjectURL(content);
-            downloadAnchorNode.download = "fishing_log_export.zip";
+            downloadAnchorNode.download = `fishing_log_export_${timestamp}.zip`;
             document.body.appendChild(downloadAnchorNode);
             downloadAnchorNode.click();
             document.body.removeChild(downloadAnchorNode);
@@ -1615,9 +1623,17 @@ function exportDataAsCSV() {
         }
 
         zip.generateAsync({type:"blob"}).then(content => {
+            const now = new Date();
+            const year = now.getFullYear();
+            const month = (now.getMonth() + 1).toString().padStart(2, '0');
+            const day = now.getDate().toString().padStart(2, '0');
+            const hours = now.getHours().toString().padStart(2, '0');
+            const minutes = now.getMinutes().toString().padStart(2, '0');
+            const timestamp = `${year}-${month}-${day}_${hours}${minutes}`;
+
             const downloadAnchorNode = document.createElement('a');
             downloadAnchorNode.href = URL.createObjectURL(content);
-            downloadAnchorNode.download = "fishing_log_csv_export.zip";
+            downloadAnchorNode.download = `fishing_log_csv_export_${timestamp}.zip`;
             document.body.appendChild(downloadAnchorNode);
             downloadAnchorNode.click();
             document.body.removeChild(downloadAnchorNode);

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'maori-fishing-calendar-cache-v4';
+const CACHE_NAME = 'maori-fishing-calendar-cache-v5';
 const urlsToCache = [
   '/',
   'index.html',


### PR DESCRIPTION
feat: Add timestamp to backup export filenames

This commit updates the backup export functionality to include a timestamp in the filename of the exported backup file.

The filename format is now `<name>_YYYY-MM-DD_hhmm.zip` as requested.

This change applies to both the JSON and CSV export options.

fix: Update service worker cache version to v5 to ensure changes are applied for users.