### PR TITLE
Move Trip Log button in Bite Time modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -160,6 +160,13 @@
                         <p id="modalMoonIllumination" class="text-sm text-gray-600 dark:text-gray-400"></p>
                     </div>
                 </div>
+                <!-- Trip Log Section -->
+                <div class="border-t dark:border-gray-700 pt-4 mb-4">
+                    <button id="open-trip-log-btn" class="w-full px-4 py-2 bg-main-500 text-white rounded-md transition">
+                        <i class="fas fa-book-open mr-2"></i> View / Manage Trip Log
+                    </button>
+                </div>
+
                 <!-- Bite Times Section -->
                 <div class="border-t dark:border-gray-700 pt-4 mb-4">
                     <h4 class="font-semibold text-lg mb-3 dark:text-gray-100">Bite Times</h4>
@@ -202,8 +209,7 @@
                     <h4 class="font-semibold text-lg mb-3 dark:text-gray-100">Sun & Moon</h4>
                     <div id="sun-moon-content" class="text-sm">
                         <!-- Sun and moon data will be injected here -->
-                        <p>Loading times...</p>
-                    </div>
+                        <p>Loading times...</p>                    </div>
                 </div>
 
                 <!-- Bite Time Quality Legend -->
@@ -231,13 +237,6 @@
                             <span class="text-sm">Poor</span>
                         </div>
                     </div>
-                </div>
-
-                <!-- Trip Log Section -->
-                <div class="border-t dark:border-gray-700 pt-4 mt-4">
-                    <button id="open-trip-log-btn" class="w-full px-4 py-2 bg-main-500 text-white rounded-md transition">
-                        <i class="fas fa-book-open mr-2"></i> View / Manage Trip Log
-                    </button>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
This commit moves the 'Trip Log' button to be above the 'Bite Time' information in the bite time modal, as requested.

The HTML for the 'Trip Log' button section in `index.html` has been moved to its new position. The CSS classes for margins have also been adjusted to maintain a consistent layout within the modal.